### PR TITLE
Require open-uri

### DIFF
--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/hash"
 
 require 'json'
+require 'open-uri'
 require 'virtus'
 require "faraday"
 require "faraday_middleware"


### PR DESCRIPTION
This allows `Kernel.open` to actually open URLs (as used in response exports and maybe elsewhere)