### PR TITLE
Add Response Export Service connection to newly created Response Export

### DIFF
--- a/lib/qualtrics_api/services/response_export_service.rb
+++ b/lib/qualtrics_api/services/response_export_service.rb
@@ -16,13 +16,13 @@ module QualtricsAPI
 
         attribute :id, String
       end
-      
+
       attr_reader :result
 
       def start
         response = QualtricsAPI.connection(self).post("responseexports", export_params)
         export_id = response.body["result"]["id"]
-        @result = ResponseExport.new(id: export_id)
+        @result = ResponseExport.new(id: export_id, connection: self.connection)
       end
 
       def export_configurations

--- a/spec/lib/services/response_export_service_spec.rb
+++ b/spec/lib/services/response_export_service_spec.rb
@@ -52,10 +52,17 @@ describe QualtricsAPI::Services::ResponseExportService do
     end
 
     describe "#start" do
+      let(:response) { double('resBody', body: { "result" => { "id" => "exportId" } }) }
+
+      before do
+        allow(QualtricsAPI.connection).to receive(:post) { response }
+        allow(QualtricsAPI::ResponseExport).to receive(:new).and_call_original
+      end
+
       it "calls url with export params" do
         expect(QualtricsAPI.connection)
           .to receive(:post)
-          .with("responseexports", 
+          .with("responseexports",
                 "format" => "file type",
                 "surveyId" => "s_id",
                 "lastResponseId" => "l_id",
@@ -71,11 +78,12 @@ describe QualtricsAPI::Services::ResponseExportService do
       end
 
       it "assigns and returns a ResponseExport with the id in the url" do
-        allow(QualtricsAPI.connection).to receive(:post)
-          .and_return(double('resBody', body: { "result" => { "id" => "exportId" } }))
-        sut = subject.start
-        expect(sut).to be_a QualtricsAPI::ResponseExport
-        expect(subject.result).to eq sut
+        expect(QualtricsAPI::ResponseExport).to receive(:new).with(id: "exportId", connection: subject.connection)
+
+        response_export = subject.start
+
+        expect(response_export).to be_a QualtricsAPI::ResponseExport
+        expect(subject.result).to eq response_export
       end
     end
   end


### PR DESCRIPTION
This PR adds the parent connection from `ResponseExportService` to a newly created `ResponseExport` in `ResponseExportService#start`.

This allows the returned `ResponseExport` to use the connection to correctly check the completion status and ultimately get the completed file url.