### PR TITLE
Add User and Library Message Models

### DIFF
--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -20,17 +20,21 @@ require "qualtrics_api/extensions/virtus_attributes"
 require "qualtrics_api/base_model"
 require "qualtrics_api/base_collection"
 
-require "qualtrics_api/survey"
-require "qualtrics_api/survey_collection"
-require "qualtrics_api/response_export"
-require "qualtrics_api/response_export_collection"
-require "qualtrics_api/panel"
-require "qualtrics_api/panel_collection"
-require "qualtrics_api/panel_member"
-require "qualtrics_api/panel_member_collection"
-require "qualtrics_api/panel_import"
 require "qualtrics_api/event_subscription"
 require "qualtrics_api/event_subscription_collection"
+require "qualtrics_api/library_message"
+require "qualtrics_api/library_message_collection"
+require "qualtrics_api/panel"
+require "qualtrics_api/panel_collection"
+require "qualtrics_api/panel_import"
+require "qualtrics_api/panel_member"
+require "qualtrics_api/panel_member_collection"
+require "qualtrics_api/response_export"
+require "qualtrics_api/response_export_collection"
+require "qualtrics_api/survey"
+require "qualtrics_api/survey_collection"
+require "qualtrics_api/user"
+require "qualtrics_api/user_collection"
 
 require "qualtrics_api/services/response_export_service"
 
@@ -43,6 +47,7 @@ module QualtricsAPI
     def_delegator :client, :response_exports
     def_delegator :client, :panels
     def_delegator :client, :event_subscriptions
+    def_delegator :client, :users
 
     def connection(parent = nil)
       return parent.connection if parent && parent.connection

--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -5,7 +5,6 @@ require 'open-uri'
 require 'virtus'
 require "faraday"
 require "faraday_middleware"
-require "pry-byebug"
 
 require "qualtrics_api/version"
 require "qualtrics_api/request_error_handler"

--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -5,6 +5,7 @@ require 'open-uri'
 require 'virtus'
 require "faraday"
 require "faraday_middleware"
+require "pry-byebug"
 
 require "qualtrics_api/version"
 require "qualtrics_api/request_error_handler"

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -22,6 +22,10 @@ module QualtricsAPI
       QualtricsAPI::EventSubscriptionCollection.new(options).propagate_connection(self)
     end
 
+    def users(options = {})
+      QualtricsAPI::UserCollection.new(options).propagate_connection(self)
+    end
+
     private
 
     def establish_connection(api_token, data_center_id)

--- a/lib/qualtrics_api/library_message.rb
+++ b/lib/qualtrics_api/library_message.rb
@@ -1,0 +1,19 @@
+module QualtricsAPI
+  class LibraryMessage < BaseModel
+    values do
+      attribute :id, String
+      attribute :description, String
+      attribute :category, String
+    end
+
+    private
+
+    def attributes_mappings
+      {
+        :id => "id",
+        :description => "description",
+        :category => "category"
+      }
+    end
+  end
+end

--- a/lib/qualtrics_api/library_message.rb
+++ b/lib/qualtrics_api/library_message.rb
@@ -4,6 +4,7 @@ module QualtricsAPI
       attribute :id, String
       attribute :description, String
       attribute :category, String
+      attribute :messages, Json
     end
 
     private
@@ -12,7 +13,8 @@ module QualtricsAPI
       {
         :id => "id",
         :description => "description",
-        :category => "category"
+        :category => "category",
+        :messages => "messages"
       }
     end
   end

--- a/lib/qualtrics_api/library_message_collection.rb
+++ b/lib/qualtrics_api/library_message_collection.rb
@@ -1,0 +1,25 @@
+module QualtricsAPI
+  class LibraryMessageCollection < BaseCollection
+    values do
+      attribute :id, String
+    end
+
+    def [](message_id)
+      find(message_id)
+    end
+
+    private
+
+    def build_result(element)
+      QualtricsAPI::LibraryMessage.new(element)
+    end
+
+    def list_endpoint
+      "libraries/#{id}/messages"
+    end
+
+    def endpoint(message_id)
+      "libraries/#{id}/messages/#{message_id}"
+    end
+  end
+end

--- a/lib/qualtrics_api/user.rb
+++ b/lib/qualtrics_api/user.rb
@@ -9,6 +9,17 @@ module QualtricsAPI
       attribute :user_type, String
       attribute :email, String
       attribute :account_status, String
+      attribute :organization_id, String
+      attribute :language, String
+      attribute :unsubscribed, Boolean
+      attribute :account_creation_date, String
+      attribute :account_expiration_date, String
+      attribute :password_last_changed_date, String
+      attribute :password_expiration_date, String
+      attribute :last_login_date, String
+      attribute :timezone, String
+      attribute :response_counts, Json
+      attribute :permissions, Json
     end
 
     def messages(options = {})
@@ -26,7 +37,18 @@ module QualtricsAPI
         :last_name => "lastName",
         :user_type => "userType",
         :email => "email",
-        :account_status => "active"
+        :account_status => "accountStatus",
+        :organization_id  => "organizationId",
+        :language  => "language",
+        :unsubscribed => "unsubscribed",
+        :account_creation_date => "accountCreationDate",
+        :account_expiration_date => "accountExpirationDate",
+        :password_last_changed_date => "passwordLastChangedDate",
+        :password_expiration_date => "passwordExpirationDate",
+        :last_login_date => "lastLoginDate",
+        :timezone => "timezone",
+        :response_counts => "responseCounts",
+        :permissions => "permissions"
       }
     end
   end

--- a/lib/qualtrics_api/user.rb
+++ b/lib/qualtrics_api/user.rb
@@ -22,12 +22,12 @@ module QualtricsAPI
       attribute :permissions, Json
     end
 
-    def messages(options = {})
-      @messages ||= message_collection.all
+    def message_collection(options = {})
+      @message_collection ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
     end
 
-    def message_collection
-      @message_collection ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
+    def messages
+      @messages ||= message_collection.all
     end
 
     private

--- a/lib/qualtrics_api/user.rb
+++ b/lib/qualtrics_api/user.rb
@@ -1,0 +1,33 @@
+module QualtricsAPI
+  class User < BaseModel
+    values do
+      attribute :id, String
+      attribute :division_id, String
+      attribute :username, String
+      attribute :first_name, String
+      attribute :last_name, String
+      attribute :user_type, String
+      attribute :email, String
+      attribute :account_status, String
+    end
+
+    def messages(options = {})
+      @messages ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
+    end
+
+    private
+
+    def attributes_mappings
+      {
+        :id => "id",
+        :division_id => "divisionId",
+        :username => "username",
+        :first_name => "firstName",
+        :last_name => "lastName",
+        :user_type => "userType",
+        :email => "email",
+        :account_status => "active"
+      }
+    end
+  end
+end

--- a/lib/qualtrics_api/user.rb
+++ b/lib/qualtrics_api/user.rb
@@ -23,7 +23,11 @@ module QualtricsAPI
     end
 
     def messages(options = {})
-      @messages ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
+      @messages ||= message_collection.all
+    end
+
+    def message_collection
+      @message_collection ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
     end
 
     private

--- a/lib/qualtrics_api/user_collection.rb
+++ b/lib/qualtrics_api/user_collection.rb
@@ -1,0 +1,21 @@
+module QualtricsAPI
+  class UserCollection < BaseCollection
+    def [](user_id)
+      find(user_id)
+    end
+
+    private
+
+    def build_result(element)
+      QualtricsAPI::User.new(element)
+    end
+
+    def list_endpoint
+      'users'
+    end
+
+    def endpoint(id)
+      "users/#{id}"
+    end
+  end
+end

--- a/qualtrics_api.gemspec
+++ b/qualtrics_api.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "pry-byebug", "~> 3.6.0"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "vcr", "~> 3.0"

--- a/qualtrics_api.gemspec
+++ b/qualtrics_api.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "pry-byebug", "~> 3.6.0"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "vcr", "~> 3.0"

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -15,6 +15,12 @@ describe QualtricsAPI::Client do
     end
   end
 
+  describe "#users" do
+    it "returns a UserCollection" do
+      expect(subject.users).to be_a QualtricsAPI::UserCollection
+    end
+  end
+
   describe "#initialize" do
     subject { QualtricsAPI::Client }
 

--- a/spec/lib/library_message_collection_spec.rb
+++ b/spec/lib/library_message_collection_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe QualtricsAPI::LibraryMessageCollection do
+  subject { described_class.new(id: library_id) }
+  let(:library_id) { "UR_aBcD1234" }
+  let(:message_response) { instance_double(Faraday::Response, status: response_status, body: response_body) }
+  let(:response_status) { 200 }
+  let(:response_body) { {
+    "result" => {
+      "id" => "MS_aBcD1234",
+      "description" => "A message!",
+      "category" => "invite",
+      "messages" => {
+        "en" => "This is a message",
+        "es" => "Este es un mensaje"
+      }
+    }
+  } }
+
+  it { is_expected.to have_attributes(id: library_id) }
+
+  describe "#find" do
+    let(:connection_double) { instance_double(Faraday::Connection) }
+    let(:message_id) { "MS_aBcD1234" }
+
+    before do
+      allow(QualtricsAPI).to receive(:connection).with(subject) { connection_double }
+      allow(connection_double).to receive(:get) { message_response }
+    end
+
+    it "calls get with the given id on the users endpoint" do
+      expect(QualtricsAPI).to receive(:connection).with(subject)
+      expect(connection_double).to receive(:get).with("libraries/#{subject.id}/messages/#{message_id}")
+      subject.find(message_id)
+    end
+
+    context "when the response status is 200" do
+      before do
+        expect(message_response.status).to eq 200
+      end
+
+      it "returns the user" do
+        expect(subject.find(message_id)).to be_a QualtricsAPI::LibraryMessage
+      end
+    end
+
+    context "when the response status is not 200" do
+      let(:response_status) { 404 }
+
+      it "returns nil" do
+        expect(subject.find(message_id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/library_message_spec.rb
+++ b/spec/lib/library_message_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper.rb"
+
+describe QualtricsAPI::LibraryMessage do
+  subject { described_class.new qualtrics_response }
+  let(:qualtrics_response) { {
+    "id" => "MS_aBcD1234",
+    "description" => "A message!",
+    "category" => "invite",
+    "messages" => {
+      "en" => "This is a message",
+      "es" => "Este es un mensaje"
+    }
+  } }
+
+  it { is_expected.to have_attributes(
+    id: qualtrics_response["id"],
+    description: qualtrics_response["description"],
+    category: qualtrics_response["category"],
+    messages: qualtrics_response["messages"])
+  }
+end

--- a/spec/lib/user_collection_spec.rb
+++ b/spec/lib/user_collection_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+describe QualtricsAPI::UserCollection do
+  subject { described_class.new }
+  let(:user_response) { instance_double(Faraday::Response, status: response_status, body: response_body) }
+  let(:response_status) { 200 }
+  let(:response_body) { {
+    "result" => {
+      "id" => "UR_aBcD1234",
+      "username" => "somedude",
+      "email" => "some@dude.com",
+      "firstName" => "some",
+      "lastName" => "dude",
+      "userType" => "UT_BRANDADMIN",
+      "organizationId" => "organization1",
+      "divisionId" => "division1",
+      "language" => "en",
+      "accountStatus" => "active",
+      "unsubscribed" => false,
+      "accountCreationDate" => "2018-07-26T22:57:58Z",
+      "accountExpirationDate" => "2019-07-26T22:57:58Z",
+      "passwordLastChangedDate" => "2018-11-15T05:27:58Z",
+      "passwordExpirationDate" => "2019-11-15T05:27:58Z",
+      "lastLoginDate" => "2018-12-12T03:17:35Z",
+      "timeZone" => "UTC-8",
+      "responseCounts" => {
+        "auditable" => 29,
+        "generated" => 3,
+        "deleted" => 0
+      },
+      "permissions" => {
+        "controlPanel" => {
+          "surveyPermissions" => {
+            "useBlocks" => {
+              "calculatedState" => "on"
+            }
+          }
+        }
+      }
+    }
+  } }
+
+  describe "#find" do
+    let(:connection_double) { instance_double(Faraday::Connection) }
+    let(:user_id) { "UR_aBcD1234" }
+
+    before do
+      allow(QualtricsAPI).to receive(:connection).with(subject) { connection_double }
+      allow(connection_double).to receive(:get) { user_response }
+    end
+
+    it "calls get with the given id on the users endpoint" do
+      expect(QualtricsAPI).to receive(:connection).with(subject)
+      expect(connection_double).to receive(:get).with("users/#{user_id}")
+      subject.find(user_id)
+    end
+
+    context "when the response status is 200" do
+      before do
+        expect(user_response.status).to eq 200
+      end
+
+      it "returns the user" do
+        expect(subject.find(user_id)).to be_a QualtricsAPI::User
+      end
+    end
+
+    context "when the response status is not 200" do
+      let(:response_status) { 404 }
+
+      it "returns nil" do
+        expect(subject.find(user_id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe QualtricsAPI::User do
+  subject { described_class.new qualtrics_response }
+  let(:collection_double) { instance_double(QualtricsAPI::LibraryMessageCollection) }
+  let(:qualtrics_response) do
+    {
+      "id" => "UR_aBcD1234",
+      "username" => "somedude",
+      "email" => "some@dude.com",
+      "firstName" => "some",
+      "lastName" => "dude",
+      "userType" => "UT_BRANDADMIN",
+      "organizationId" => "organization1",
+      "divisionId" => "division1",
+      "language" => "en",
+      "accountStatus" => "active",
+      "unsubscribed" => false,
+      "accountCreationDate" => "2018-07-26T22:57:58Z",
+      "accountExpirationDate" => "2019-07-26T22:57:58Z",
+      "passwordLastChangedDate" => "2018-11-15T05:27:58Z",
+      "passwordExpirationDate" => "2019-11-15T05:27:58Z",
+      "lastLoginDate" => "2018-12-12T03:17:35Z",
+      "timeZone" => "UTC-8",
+      "responseCounts" => {
+        "auditable" => 29,
+        "generated" => 3,
+        "deleted" => 0
+      },
+      "permissions" => {
+        "controlPanel" => {
+          "surveyPermissions" => {
+            "useBlocks" => {
+              "calculatedState" => "on"
+            }
+          }
+        }
+      }
+    }
+  end
+
+  before do
+    allow(QualtricsAPI::LibraryMessageCollection).to receive(:new) { collection_double }
+    allow(collection_double).to receive(:propagate_connection) { collection_double }
+  end
+
+  it { is_expected.to have_attributes(
+    :id => qualtrics_response["id"],
+    :division_id => qualtrics_response["divisionId"],
+    :username => qualtrics_response["username"],
+    :first_name => qualtrics_response["firstName"],
+    :last_name => qualtrics_response["lastName"],
+    :user_type => qualtrics_response["userType"],
+    :email => qualtrics_response["email"],
+    :account_status => qualtrics_response["accountStatus"],
+    :organization_id  => qualtrics_response["organizationId"],
+    :language  => qualtrics_response["language"],
+    :unsubscribed => qualtrics_response["unsubscribed"],
+    :account_creation_date => qualtrics_response["accountCreationDate"],
+    :account_expiration_date => qualtrics_response["accountExpirationDate"],
+    :password_last_changed_date => qualtrics_response["passwordLastChangedDate"],
+    :password_expiration_date => qualtrics_response["passwordExpirationDate"],
+    :last_login_date => qualtrics_response["lastLoginDate"],
+    :timezone => qualtrics_response["timezone"],
+    :response_counts => qualtrics_response["responseCounts"],
+    :permissions => qualtrics_response["permissions"].deep_transform_keys { |key| key.underscore.to_sym })
+  }
+
+  describe "#message_collection" do
+    it "creates a LibraryMessageCollection with the same connection" do
+      expect(QualtricsAPI::LibraryMessageCollection).to receive(:new).with(id: subject.id)
+      expect(collection_double).to receive(:propagate_connection).with(subject)
+      expect(subject.message_collection).to be collection_double
+    end
+  end
+
+  describe "#messages" do
+    it "gets all messages for the user" do
+      expect(collection_double).to receive(:all)
+      subject.messages
+    end
+  end
+end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -3,41 +3,39 @@ require 'spec_helper'
 describe QualtricsAPI::User do
   subject { described_class.new qualtrics_response }
   let(:collection_double) { instance_double(QualtricsAPI::LibraryMessageCollection) }
-  let(:qualtrics_response) do
-    {
-      "id" => "UR_aBcD1234",
-      "username" => "somedude",
-      "email" => "some@dude.com",
-      "firstName" => "some",
-      "lastName" => "dude",
-      "userType" => "UT_BRANDADMIN",
-      "organizationId" => "organization1",
-      "divisionId" => "division1",
-      "language" => "en",
-      "accountStatus" => "active",
-      "unsubscribed" => false,
-      "accountCreationDate" => "2018-07-26T22:57:58Z",
-      "accountExpirationDate" => "2019-07-26T22:57:58Z",
-      "passwordLastChangedDate" => "2018-11-15T05:27:58Z",
-      "passwordExpirationDate" => "2019-11-15T05:27:58Z",
-      "lastLoginDate" => "2018-12-12T03:17:35Z",
-      "timeZone" => "UTC-8",
-      "responseCounts" => {
-        "auditable" => 29,
-        "generated" => 3,
-        "deleted" => 0
-      },
-      "permissions" => {
-        "controlPanel" => {
-          "surveyPermissions" => {
-            "useBlocks" => {
-              "calculatedState" => "on"
-            }
+  let(:qualtrics_response) { {
+    "id" => "UR_aBcD1234",
+    "username" => "somedude",
+    "email" => "some@dude.com",
+    "firstName" => "some",
+    "lastName" => "dude",
+    "userType" => "UT_BRANDADMIN",
+    "organizationId" => "organization1",
+    "divisionId" => "division1",
+    "language" => "en",
+    "accountStatus" => "active",
+    "unsubscribed" => false,
+    "accountCreationDate" => "2018-07-26T22:57:58Z",
+    "accountExpirationDate" => "2019-07-26T22:57:58Z",
+    "passwordLastChangedDate" => "2018-11-15T05:27:58Z",
+    "passwordExpirationDate" => "2019-11-15T05:27:58Z",
+    "lastLoginDate" => "2018-12-12T03:17:35Z",
+    "timeZone" => "UTC-8",
+    "responseCounts" => {
+      "auditable" => 29,
+      "generated" => 3,
+      "deleted" => 0
+    },
+    "permissions" => {
+      "controlPanel" => {
+        "surveyPermissions" => {
+          "useBlocks" => {
+            "calculatedState" => "on"
           }
         }
       }
     }
-  end
+  } }
 
   before do
     allow(QualtricsAPI::LibraryMessageCollection).to receive(:new) { collection_double }
@@ -45,25 +43,25 @@ describe QualtricsAPI::User do
   end
 
   it { is_expected.to have_attributes(
-    :id => qualtrics_response["id"],
-    :division_id => qualtrics_response["divisionId"],
-    :username => qualtrics_response["username"],
-    :first_name => qualtrics_response["firstName"],
-    :last_name => qualtrics_response["lastName"],
-    :user_type => qualtrics_response["userType"],
-    :email => qualtrics_response["email"],
-    :account_status => qualtrics_response["accountStatus"],
-    :organization_id  => qualtrics_response["organizationId"],
-    :language  => qualtrics_response["language"],
-    :unsubscribed => qualtrics_response["unsubscribed"],
-    :account_creation_date => qualtrics_response["accountCreationDate"],
-    :account_expiration_date => qualtrics_response["accountExpirationDate"],
-    :password_last_changed_date => qualtrics_response["passwordLastChangedDate"],
-    :password_expiration_date => qualtrics_response["passwordExpirationDate"],
-    :last_login_date => qualtrics_response["lastLoginDate"],
-    :timezone => qualtrics_response["timezone"],
-    :response_counts => qualtrics_response["responseCounts"],
-    :permissions => qualtrics_response["permissions"].deep_transform_keys { |key| key.underscore.to_sym })
+    id: qualtrics_response["id"],
+    division_id: qualtrics_response["divisionId"],
+    username: qualtrics_response["username"],
+    first_name: qualtrics_response["firstName"],
+    last_name: qualtrics_response["lastName"],
+    user_type: qualtrics_response["userType"],
+    email: qualtrics_response["email"],
+    account_status: qualtrics_response["accountStatus"],
+    organization_id: qualtrics_response["organizationId"],
+    language: qualtrics_response["language"],
+    unsubscribed: qualtrics_response["unsubscribed"],
+    account_creation_date: qualtrics_response["accountCreationDate"],
+    account_expiration_date: qualtrics_response["accountExpirationDate"],
+    password_last_changed_date: qualtrics_response["passwordLastChangedDate"],
+    password_expiration_date: qualtrics_response["passwordExpirationDate"],
+    last_login_date: qualtrics_response["lastLoginDate"],
+    timezone: qualtrics_response["timezone"],
+    response_counts: qualtrics_response["responseCounts"],
+    permissions: qualtrics_response["permissions"].deep_transform_keys { |key| key.underscore.to_sym })
   }
 
   describe "#message_collection" do


### PR DESCRIPTION
This PR adds `User` and `LibraryMessage` models along with their collection models. It also adds support for filtering collections with query parameters (i.e. user's username).

Additionally, it also adds `pry-byebug` as a development dependency.