### PR TITLE
Add Distributions

### DIFF
--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -20,6 +20,7 @@ require "qualtrics_api/extensions/virtus_attributes"
 require "qualtrics_api/base_model"
 require "qualtrics_api/base_collection"
 
+require "qualtrics_api/distribution"
 require "qualtrics_api/event_subscription"
 require "qualtrics_api/event_subscription_collection"
 require "qualtrics_api/library_message"

--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -22,6 +22,7 @@ require "qualtrics_api/base_model"
 require "qualtrics_api/base_collection"
 
 require "qualtrics_api/distribution"
+require "qualtrics_api/distribution_collection"
 require "qualtrics_api/event_subscription"
 require "qualtrics_api/event_subscription_collection"
 require "qualtrics_api/library_message"
@@ -50,6 +51,7 @@ module QualtricsAPI
     def_delegator :client, :panels
     def_delegator :client, :event_subscriptions
     def_delegator :client, :users
+    def_delegator :client, :distributions
 
     def connection(parent = nil)
       return parent.connection if parent && parent.connection

--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/hash"
+require "active_support/core_ext/string"
 
 require 'json'
 require 'open-uri'

--- a/lib/qualtrics_api/base_collection.rb
+++ b/lib/qualtrics_api/base_collection.rb
@@ -48,8 +48,8 @@ module QualtricsAPI
       end
     end
 
-    def find(id)
-      response = QualtricsAPI.connection(self).get(endpoint(id))
+    def find(id, options = {})
+      response = QualtricsAPI.connection(self).get(endpoint(id), options)
       return nil unless response.status == 200
       build_result(response.body['result']).propagate_connection(self)
     end

--- a/lib/qualtrics_api/base_collection.rb
+++ b/lib/qualtrics_api/base_collection.rb
@@ -41,7 +41,7 @@ module QualtricsAPI
       endpoint = list_endpoint
 
       loop do
-        response = QualtricsAPI.connection(self).get(endpoint, options)
+        response = QualtricsAPI.connection(self).get(endpoint, camelize_keys(options))
         endpoint = response.body["result"]["nextPage"]
         yield parse_page(response)
         break unless endpoint
@@ -49,7 +49,7 @@ module QualtricsAPI
     end
 
     def find(id, options = {})
-      response = QualtricsAPI.connection(self).get(endpoint(id), options)
+      response = QualtricsAPI.connection(self).get(endpoint(id), camelize_keys(options))
       return nil unless response.status == 200
       build_result(response.body['result']).propagate_connection(self)
     end
@@ -70,6 +70,10 @@ module QualtricsAPI
       else
         Array.wrap(build_result(response.body["result"]).propagate_connection(self))
       end
+    end
+
+    def camelize_keys(hash)
+      hash.deep_transform_keys { |key| key.to_s.camelize(:lower) }
     end
   end
 end

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -26,6 +26,10 @@ module QualtricsAPI
       QualtricsAPI::UserCollection.new(options).propagate_connection(self)
     end
 
+    def distributions(options = {})
+      QualtricsAPI::DistributionCollection.new(options).propagate_connection(self)
+    end
+
     private
 
     def establish_connection(api_token, data_center_id)

--- a/lib/qualtrics_api/distribution.rb
+++ b/lib/qualtrics_api/distribution.rb
@@ -1,0 +1,58 @@
+module QualtricsAPI
+  class Distribution < BaseModel
+    values do
+      attribute :id, String
+      attribute :parent_distribution_id, String
+      attribute :owner_id, String
+      attribute :organization_id, String
+      attribute :request_status, String
+      attribute :request_type, String
+      attribute :send_date, String
+      attribute :created_date, String
+      attribute :modified_date, String
+      attribute :headers, Json
+      attribute :recipients, Json
+      attribute :message, Json
+      attribute :survey_link, Json
+      attribute :embedded_data, Json
+      attribute :stats, Json
+    end
+
+    private
+
+    def create_attributes
+      self.attributes.slice(create_attributes_mappings.keys)
+    end
+
+    def create_attributes_mappings
+      {
+        send_date: "sendDate",
+        header: "header",
+        recipients: "recipients",
+        message: "message",
+        survey_link: "surveyLink",
+        embedded_data: "embeddedData"
+      }
+    end
+
+    def attributes_mappings
+      {
+        id: "id",
+        parent_distribution_id: "parentDistributionId",
+        owner_id: "ownerId",
+        organization_id: "organizationId",
+        request_status: "requestStatus",
+        request_type: "requestType",
+        send_date: "sendDate",
+        created_date: "createdDate",
+        modified_date: "modifiedDate",
+        headers: "headers",
+        recipients: "recipients",
+        message: "message",
+        survey_link: "surveyLink",
+        embedded_data: "embeddedData",
+        stats: "stats"
+      }
+    end
+  end
+end

--- a/lib/qualtrics_api/distribution.rb
+++ b/lib/qualtrics_api/distribution.rb
@@ -18,10 +18,17 @@ module QualtricsAPI
       attribute :stats, Json
     end
 
+    def create
+      response = QualtricsAPI.connection(self).post("distributions", create_attributes).body["result"]
+
+      QualtricsAPI::Distribution.new(self.attributes.merge(id: response["id"]))
+    end
+
     private
 
     def create_attributes
-      self.attributes.slice(create_attributes_mappings.keys)
+      attrs = self.attributes.compact.slice(*create_attributes_mappings.keys).merge(header: self.headers)
+      attrs.deep_transform_keys { |key| key.to_s.camelize(:lower) }
     end
 
     def create_attributes_mappings

--- a/lib/qualtrics_api/distribution_collection.rb
+++ b/lib/qualtrics_api/distribution_collection.rb
@@ -1,0 +1,21 @@
+module QualtricsAPI
+  class DistributionCollection < BaseCollection
+    def find(id, survey_id)
+      super(id, { "surveyId" => survey_id })
+    end
+
+    private
+
+    def build_result(element)
+      QualtricsAPI::Distribution.new(element)
+    end
+
+    def list_endpoint
+      "distributions"
+    end
+
+    def endpoint(distribution_id)
+      "distributions/#{distribution_id}"
+    end
+  end
+end

--- a/lib/qualtrics_api/distribution_collection.rb
+++ b/lib/qualtrics_api/distribution_collection.rb
@@ -1,7 +1,11 @@
 module QualtricsAPI
   class DistributionCollection < BaseCollection
-    def find(id, survey_id)
-      super(id, { "surveyId" => survey_id })
+    def find(id, survey_id = nil, options = {})
+      if survey_id.nil?
+        raise ArgumentError.new("`survey_id` must be included when finding a distribution")
+      end
+
+      super(id, options.merge("surveyId" => survey_id))
     end
 
     private

--- a/lib/qualtrics_api/distribution_collection.rb
+++ b/lib/qualtrics_api/distribution_collection.rb
@@ -1,11 +1,11 @@
 module QualtricsAPI
   class DistributionCollection < BaseCollection
-    def find(id, survey_id = nil, options = {})
-      if survey_id.nil?
-        raise ArgumentError.new("`survey_id` must be included when finding a distribution")
+    def find(id, options = {})
+      if camelize_keys(options)["surveyId"].nil?
+        raise ArgumentError.new("`surveyId` must be included when finding a distribution")
       end
 
-      super(id, options.merge("surveyId" => survey_id))
+      super
     end
 
     private

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -21,6 +21,12 @@ describe QualtricsAPI::Client do
     end
   end
 
+  describe "#distributions" do
+    it "returns a DistributionCollection" do
+      expect(subject.distributions).to be_a QualtricsAPI::DistributionCollection
+    end
+  end
+
   describe "#initialize" do
     subject { QualtricsAPI::Client }
 

--- a/spec/lib/distribution_collection_spec.rb
+++ b/spec/lib/distribution_collection_spec.rb
@@ -69,7 +69,7 @@ describe QualtricsAPI::DistributionCollection do
     it "calls get with the given id on the users endpoint" do
       expect(QualtricsAPI).to receive(:connection).with(subject)
       expect(connection_double).to receive(:get).with("distributions/#{distribution_id}", { "surveyId" => survey_id })
-      subject.find(distribution_id, survey_id)
+      subject.find(distribution_id, survey_id: survey_id)
     end
 
     context "when the response status is 200" do
@@ -78,7 +78,7 @@ describe QualtricsAPI::DistributionCollection do
       end
 
       it "returns the user" do
-        expect(subject.find(distribution_id, survey_id)).to be_a QualtricsAPI::Distribution
+        expect(subject.find(distribution_id, survey_id: survey_id)).to be_a QualtricsAPI::Distribution
       end
     end
 
@@ -86,13 +86,13 @@ describe QualtricsAPI::DistributionCollection do
       let(:response_status) { 404 }
 
       it "returns nil" do
-        expect(subject.find(distribution_id, survey_id)).to be_nil
+        expect(subject.find(distribution_id, survey_id: survey_id)).to be_nil
       end
     end
 
     context "when surveyId is not given" do
       it "raises an ArgumentError" do
-        expect { subject.find(distribution_id) }.to raise_error(ArgumentError, "`survey_id` must be included when finding a distribution")
+        expect { subject.find(distribution_id) }.to raise_error(ArgumentError, "`surveyId` must be included when finding a distribution")
       end
     end
   end

--- a/spec/lib/distribution_collection_spec.rb
+++ b/spec/lib/distribution_collection_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper"
+
+describe QualtricsAPI::DistributionCollection do
+  subject { described_class.new }
+  let(:connection_double) { instance_double(Faraday::Connection) }
+  let(:distribution_response) { instance_double(Faraday::Response, status: response_status, body: response_body) }
+  let(:response_status) { 200 }
+  let(:response_body) { {
+    "result" => {
+      "id" => "EMD_abc123",
+      "parentDistributionId" => "EMD_parent",
+      "ownerId" => "UR_abc123",
+      "organizationId" => "apitest",
+      "requestStatus" => "Done",
+      "requestType" => "Invite",
+      "sendDate" => "2014-02-18T22:57:04Z",
+      "createdDate" => "2014-02-18T22:57:04Z",
+      "modifiedDate" => "2014-02-19T22:57:04Z",
+      "headers" => {
+        "fromEmail" => "apitest@qualtrics.com",
+        "replyToEmail" => "apitest@qualtrics.com",
+        "fromName" => "Api Test",
+        "subject" => "flow test"
+      },
+      "recipients" => {
+        "mailingListId" => "ML_abc123",
+        "contactId" => "C_abc123",
+        "libraryId" => "UR_abc123",
+        "sampleId" => "S_abc123"
+      },
+      "message" => {
+        "libraryId" => "UR_abc123",
+        "messageId" => "MS_abc123",
+        "messageText" => "This is a message"
+      },
+      "surveyLink" => {
+        "surveyId" => "SV_abc123",
+        "expirationDate" => "2014-04-19T21:57:04Z",
+        "linkType" => "Individual"
+      },
+      "embeddedData" => {
+        "emailAuthor" => "bob",
+        "emailType" => "leading question"
+      },
+      "stats" => {
+        "sent" => 2,
+        "failed" => 0,
+        "started" => 2,
+        "bounced" => 0,
+        "opened" => 2,
+        "skipped" => 0,
+        "finished" => 2,
+        "complaints" => 0,
+        "blocked" => 0
+      }
+    }
+  } }
+
+  before do
+    allow(QualtricsAPI).to receive(:connection).with(subject) { connection_double }
+    allow(connection_double).to receive(:get) { distribution_response }
+  end
+
+  describe "#find" do
+    let(:connection_double) { instance_double(Faraday::Connection) }
+    let(:distribution_id) { "EMD_abc123" }
+    let(:survey_id) { "SV_abc123" }
+
+    it "calls get with the given id on the users endpoint" do
+      expect(QualtricsAPI).to receive(:connection).with(subject)
+      expect(connection_double).to receive(:get).with("distributions/#{distribution_id}", { "surveyId" => survey_id })
+      subject.find(distribution_id, survey_id)
+    end
+
+    context "when the response status is 200" do
+      before do
+        expect(distribution_response.status).to eq 200
+      end
+
+      it "returns the user" do
+        expect(subject.find(distribution_id, survey_id)).to be_a QualtricsAPI::Distribution
+      end
+    end
+
+    context "when the response status is not 200" do
+      let(:response_status) { 404 }
+
+      it "returns nil" do
+        expect(subject.find(distribution_id, survey_id)).to be_nil
+      end
+    end
+  end
+
+  describe "#filter" do
+    let(:filters) { { "surveyId" => "SV_abc123" } }
+
+    it "calls get with the given options on the users endpoint" do
+      expect(QualtricsAPI).to receive(:connection).with(subject)
+      expect(connection_double).to receive(:get).with("distributions", filters)
+      subject.filter(filters)
+    end
+
+    it "returns the result array of filtered objects" do
+      expect(subject.filter(filters)).to include a_kind_of QualtricsAPI::Distribution
+    end
+  end
+end

--- a/spec/lib/distribution_collection_spec.rb
+++ b/spec/lib/distribution_collection_spec.rb
@@ -89,6 +89,12 @@ describe QualtricsAPI::DistributionCollection do
         expect(subject.find(distribution_id, survey_id)).to be_nil
       end
     end
+
+    context "when surveyId is not given" do
+      it "raises an ArgumentError" do
+        expect { subject.find(distribution_id) }.to raise_error(ArgumentError, "`survey_id` must be included when finding a distribution")
+      end
+    end
   end
 
   describe "#filter" do

--- a/spec/lib/distribution_spec.rb
+++ b/spec/lib/distribution_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+describe QualtricsAPI::Distribution do
+  subject { described_class.new qualtrics_response }
+  let(:qualtrics_response) { {
+    "id" => "EMD_abc123",
+    "parentDistributionId" => "EMD_parent",
+    "ownerId" => "UR_abc123",
+    "organizationId" => "apitest",
+    "requestStatus" => "Done",
+    "requestType" => "Invite",
+    "sendDate" => "2014-02-18T22:57:04Z",
+    "createdDate" => "2014-02-18T22:57:04Z",
+    "modifiedDate" => "2014-02-19T22:57:04Z",
+    "headers" => {
+      "fromEmail" => "apitest@qualtrics.com",
+      "replyToEmail" => "apitest@qualtrics.com",
+      "fromName" => "Api Test",
+      "subject" => "flow test"
+    },
+    "recipients" => {
+      "mailingListId" => "ML_abc123",
+      "contactId" => "C_abc123",
+      "libraryId" => "UR_abc123",
+      "sampleId" => "S_abc123"
+    },
+    "message" => {
+      "libraryId" => "UR_abc123",
+      "messageId" => "MS_abc123",
+      "messageText" => "This is a message"
+    },
+    "surveyLink" => {
+      "surveyId" => "SV_abc123",
+      "expirationDate" => "2014-04-19T21:57:04Z",
+      "linkType" => "Individual"
+    },
+    "embeddedData" => {
+      "emailAuthor" => "bob",
+      "emailType" => "leading question"
+    },
+    "stats" => {
+      "sent" => 2,
+      "failed" => 0,
+      "started" => 2,
+      "bounced" => 0,
+      "opened" => 2,
+      "skipped" => 0,
+      "finished" => 2,
+      "complaints" => 0,
+      "blocked" => 0
+    }
+  } }
+
+  it { is_expected.to have_attributes(
+    id: qualtrics_response["id"],
+    parent_distribution_id: qualtrics_response["parentDistributionId"],
+    owner_id: qualtrics_response["ownerId"],
+    organization_id: qualtrics_response["organizationId"],
+    request_status: qualtrics_response["requestStatus"],
+    request_type: qualtrics_response["requestType"],
+    send_date: qualtrics_response["sendDate"],
+    created_date: qualtrics_response["createdDate"],
+    modified_date: qualtrics_response["modifiedDate"],
+    headers: qualtrics_response["headers"].deep_transform_keys { |key| key.underscore.to_sym },
+    recipients: qualtrics_response["recipients"].deep_transform_keys { |key| key.underscore.to_sym },
+    message: qualtrics_response["message"].deep_transform_keys { |key| key.underscore.to_sym },
+    survey_link: qualtrics_response["surveyLink"],
+    embedded_data: qualtrics_response["embeddedData"],
+    stats: qualtrics_response["stats"])
+  }
+end

--- a/spec/lib/distribution_spec.rb
+++ b/spec/lib/distribution_spec.rb
@@ -68,4 +68,57 @@ describe QualtricsAPI::Distribution do
     embedded_data: qualtrics_response["embeddedData"],
     stats: qualtrics_response["stats"])
   }
+
+  describe "#create" do
+    let(:request_attributes) { {
+      "sendDate" => "2014-02-18T22:57:04Z",
+      "header" => {
+        "fromEmail" => "apitest@qualtrics.com",
+        "replyToEmail" => "apitest@qualtrics.com",
+        "fromName" => "Api Test",
+        "subject" => "flow test"
+      },
+      "recipients" => {
+        "mailingListId" => "ML_abc123",
+        "contactId" => "C_abc123",
+        "libraryId" => "UR_abc123",
+        "sampleId" => "S_abc123"
+      },
+      "message" => {
+        "libraryId" => "UR_abc123",
+        "messageId" => "MS_abc123",
+        "messageText" => "This is a message"
+      },
+      "surveyLink" => {
+        "surveyId" => "SV_abc123",
+        "expirationDate" => "2014-04-19T21:57:04Z",
+        "linkType" => "Individual"
+      },
+      "embeddedData" => {
+        "emailAuthor" => "bob",
+        "emailType" => "leading question"
+      }
+    } }
+    let(:connection_double) { instance_double(Faraday::Connection) }
+    let(:distribution_response) { instance_double(Faraday::Response, body: distribution_response_body) }
+    let(:distribution_response_body) { { "result" => request_attributes.merge("id" => "EMD_abc123") } }
+
+    context "when successful" do
+      before do
+        allow(QualtricsAPI).to receive(:connection).with(subject) { connection_double }
+        allow(connection_double).to receive(:post) { distribution_response }
+      end
+
+      it "calls the Qualtrics API with the correct payload attributes" do
+        expect(connection_double).to receive(:post).with("distributions", request_attributes)
+        subject.create
+      end
+
+      it "returns the Panel with response id" do
+        saved_subject = subject.create
+        expect(saved_subject).to be_a QualtricsAPI::Distribution
+        expect(saved_subject.id).to eq distribution_response.body["result"]["id"]
+      end
+    end
+  end
 end

--- a/spec/lib/library_message_collection_spec.rb
+++ b/spec/lib/library_message_collection_spec.rb
@@ -30,7 +30,7 @@ describe QualtricsAPI::LibraryMessageCollection do
 
     it "calls get with the given id on the users endpoint" do
       expect(QualtricsAPI).to receive(:connection).with(subject)
-      expect(connection_double).to receive(:get).with("libraries/#{subject.id}/messages/#{message_id}")
+      expect(connection_double).to receive(:get).with("libraries/#{subject.id}/messages/#{message_id}", {})
       subject.find(message_id)
     end
 

--- a/spec/lib/user_collection_spec.rb
+++ b/spec/lib/user_collection_spec.rb
@@ -51,7 +51,7 @@ describe QualtricsAPI::UserCollection do
 
     it "calls get with the given id on the users endpoint" do
       expect(QualtricsAPI).to receive(:connection).with(subject)
-      expect(connection_double).to receive(:get).with("users/#{user_id}")
+      expect(connection_double).to receive(:get).with("users/#{user_id}", {})
       subject.find(user_id)
     end
 

--- a/spec/lib/user_collection_spec.rb
+++ b/spec/lib/user_collection_spec.rb
@@ -75,7 +75,7 @@ describe QualtricsAPI::UserCollection do
   end
 
   describe "#filter" do
-    let(:filters) { { username: "someuser" } }
+    let(:filters) { { "username" => "someuser" } }
 
     it "calls get with the given options on the users endpoint" do
       expect(QualtricsAPI).to receive(:connection).with(subject)


### PR DESCRIPTION
This PR adds Distribution and DistributionCollection models. It also updates `BaseCollection#find` to accept optional query parameters (a requirement to get distributions by id because `surveyId` is a required query parameter).