### PR TITLE
Fix Panel Issues

### DIFF
--- a/lib/qualtrics_api/panel.rb
+++ b/lib/qualtrics_api/panel.rb
@@ -30,7 +30,7 @@ module QualtricsAPI
     private
 
     def create_attributes
-      self.attributes.slice(*create_attributes_mappings.keys)
+      self.attributes.compact.slice(*create_attributes_mappings.keys)
     end
 
     def create_attributes_mappings

--- a/spec/lib/panel_collection_spec.rb
+++ b/spec/lib/panel_collection_spec.rb
@@ -10,16 +10,22 @@ describe QualtricsAPI::PanelCollection do
       end
 
       context 'when exists' do
-        let(:panel_id) { 'ML_00c5BS2WNUCWQIt' } 
-      
+        let(:panel_id) { 'ML_00c5BS2WNUCWQIt' }
+
         it 'populates the result' do
-          expect(result.attributes).to eq(:id => "ML_00c5BS2WNUCWQIt", :library_id => "UR_5dURLpfp5tm43EV", :name => "Panel name", :category => "Unassigned")
+          expect(result.attributes).to eq({
+            :id => "ML_00c5BS2WNUCWQIt",
+            :folder => nil,
+            :library_id => "UR_5dURLpfp5tm43EV",
+            :name => "Panel name",
+            :category => "Unassigned"
+          })
         end
       end
-    
+
       context 'when does not exists' do
-        let(:panel_id) { 'ML_00c5BS2WNUCWQI0' } 
-      
+        let(:panel_id) { 'ML_00c5BS2WNUCWQI0' }
+
         it 'raises bad request error' do
           expect { result }.to raise_error(QualtricsAPI::BadRequestError)
         end


### PR DESCRIPTION
This PR fixes two issues missed in #5:

* Compacting `Panel#create_attributes` to exclude empty ones from the HTTP post attributes
* Updating the PanelCollection attributes spec to include the new `folder` attribute