### PR TITLE
Fix nested attribute symbol underscoring

### DIFF
--- a/lib/qualtrics_api/extensions/virtus_attributes.rb
+++ b/lib/qualtrics_api/extensions/virtus_attributes.rb
@@ -8,7 +8,7 @@ module QualtricsAPI
           value = JSON.parse(value) unless value.is_a? ::Hash
 
           value.deep_transform_keys do |key|
-            key.upcase == key ? key.to_sym : key.underscore.to_sym
+            key.upcase == key ? key.to_sym : key.to_s.underscore.to_sym
           end.with_indifferent_access
         end
       end


### PR DESCRIPTION
This PR fixes an issue where if an attributes hash with nested symbol keys is given when creating an object, it will fail because Virtus is attempting to `underscore` a symbol.