### PR TITLE
Propagate existing connection to newly created objects after creation

### DIFF
--- a/lib/qualtrics_api/distribution.rb
+++ b/lib/qualtrics_api/distribution.rb
@@ -21,7 +21,7 @@ module QualtricsAPI
     def create
       response = QualtricsAPI.connection(self).post("distributions", create_attributes).body["result"]
 
-      QualtricsAPI::Distribution.new(self.attributes.merge(id: response["id"]))
+      QualtricsAPI::Distribution.new(self.attributes.merge(id: response["id"])).propagate_connection(self)
     end
 
     private

--- a/lib/qualtrics_api/panel.rb
+++ b/lib/qualtrics_api/panel.rb
@@ -24,7 +24,7 @@ module QualtricsAPI
       payload  = create_attributes.transform_keys { |key| create_attributes_mappings[key] }
       response = QualtricsAPI.connection(self).post("mailinglists", payload).body["result"]
 
-      QualtricsAPI::Panel.new(self.attributes.merge(id: response["id"]))
+      QualtricsAPI::Panel.new(self.attributes.merge(id: response["id"])).propagate_connection(self)
     end
 
     private

--- a/lib/qualtrics_api/panel_member_collection.rb
+++ b/lib/qualtrics_api/panel_member_collection.rb
@@ -9,9 +9,9 @@ module QualtricsAPI
       res = QualtricsAPI.connection(self)
                   .post("mailinglists/#{id}/contacts", payload)
                   .body["result"]
-      return QualtricsAPI::PanelMember.new(panel_member.attributes.merge({ id: res['id'] }))
+      return QualtricsAPI::PanelMember.new(panel_member.attributes.merge({ id: res['id'] })).propagate_connection(self)
     end
-  
+
     def import_members(panel_members)
       payload = {
         contacts: Faraday::UploadIO.new(StringIO.new(panel_members.to_json), 'application/json', 'contacts.json')
@@ -32,7 +32,7 @@ module QualtricsAPI
     end
 
     private
-  
+
     def build_result(element)
       QualtricsAPI::PanelMember.new(element)
     end


### PR DESCRIPTION
This PR adds the current connection to the objects newly created after `POST`ing. This is needed specifically for Panels to import members after, but I think it's appropriate to add it to all newly created objects.