### PR TITLE
Add support for Groups

### DIFF
--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -20,11 +20,14 @@ require "qualtrics_api/extensions/virtus_attributes"
 
 require "qualtrics_api/base_model"
 require "qualtrics_api/base_collection"
+require "qualtrics_api/library"
 
 require "qualtrics_api/distribution"
 require "qualtrics_api/distribution_collection"
 require "qualtrics_api/event_subscription"
 require "qualtrics_api/event_subscription_collection"
+require "qualtrics_api/group"
+require "qualtrics_api/group_collection"
 require "qualtrics_api/library_message"
 require "qualtrics_api/library_message_collection"
 require "qualtrics_api/panel"
@@ -52,6 +55,7 @@ module QualtricsAPI
     def_delegator :client, :event_subscriptions
     def_delegator :client, :users
     def_delegator :client, :distributions
+    def_delegator :client, :groups
 
     def connection(parent = nil)
       return parent.connection if parent && parent.connection

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -30,6 +30,10 @@ module QualtricsAPI
       QualtricsAPI::DistributionCollection.new(options).propagate_connection(self)
     end
 
+    def groups(options = {})
+      QualtricsAPI::GroupCollection.new(options).propagate_connection(self)
+    end
+
     private
 
     def establish_connection(api_token, data_center_id)

--- a/lib/qualtrics_api/group.rb
+++ b/lib/qualtrics_api/group.rb
@@ -1,0 +1,27 @@
+module QualtricsAPI
+  class Group < Library
+    values do
+      attribute :id, String
+      attribute :type, String
+      attribute :division_id, String
+      attribute :name, String
+      attribute :auto_membership, Boolean
+      attribute :creation_date, String
+      attribute :creator_id, String
+    end
+
+    private
+
+    def attributes_mappings
+      {
+        :id => "id",
+        :type => "type",
+        :division_id => "divisionId",
+        :name => "name",
+        :auto_membership => "autoMembership",
+        :creation_date => "creationDate",
+        :creator_id => "creatorId"
+      }
+    end
+  end
+end

--- a/lib/qualtrics_api/group_collection.rb
+++ b/lib/qualtrics_api/group_collection.rb
@@ -11,7 +11,7 @@ module QualtricsAPI
     end
 
     def list_endpoint
-      'groups'
+      "groups"
     end
 
     def endpoint(id)

--- a/lib/qualtrics_api/group_collection.rb
+++ b/lib/qualtrics_api/group_collection.rb
@@ -1,0 +1,21 @@
+module QualtricsAPI
+  class GroupCollection < BaseCollection
+    def [](group_id)
+      find(group_id)
+    end
+
+    private
+
+    def build_result(element)
+      QualtricsAPI::Group.new(element)
+    end
+
+    def list_endpoint
+      'groups'
+    end
+
+    def endpoint(id)
+      "groups/#{id}"
+    end
+  end
+end

--- a/lib/qualtrics_api/library.rb
+++ b/lib/qualtrics_api/library.rb
@@ -1,0 +1,13 @@
+module QualtricsAPI
+  class Library < BaseModel
+
+
+    def message_collection(options = {})
+      @message_collection ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
+    end
+
+    def messages
+      @messages ||= message_collection.all
+    end
+  end
+end

--- a/lib/qualtrics_api/user.rb
+++ b/lib/qualtrics_api/user.rb
@@ -1,5 +1,5 @@
 module QualtricsAPI
-  class User < BaseModel
+  class User < Library
     values do
       attribute :id, String
       attribute :division_id, String
@@ -20,14 +20,6 @@ module QualtricsAPI
       attribute :timezone, String
       attribute :response_counts, Json
       attribute :permissions, Json
-    end
-
-    def message_collection(options = {})
-      @message_collection ||= QualtricsAPI::LibraryMessageCollection.new(options.merge(id: id)).propagate_connection(self)
-    end
-
-    def messages
-      @messages ||= message_collection.all
     end
 
     private

--- a/spec/lib/group_collection_spec.rb
+++ b/spec/lib/group_collection_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe QualtricsAPI::GroupCollection do
+  subject { described_class.new }
+  let(:connection_double) { instance_double(Faraday::Connection) }
+  let(:group_response) { instance_double(Faraday::Response, status: response_status, body: response_body) }
+  let(:response_status) { 200 }
+  let(:response_body) { {
+    "result" => {
+      "id" => "UR_aBcD1234",
+      "type" => "invite",
+      "divisionId" => "D_abc123",
+      "name" => "Group One",
+      "autoMembership" => false,
+      "creationDate" => "2019-01-01",
+      "creatorId" => "U_abc123"
+    }
+  } }
+
+  before do
+    allow(QualtricsAPI).to receive(:connection).with(subject) { connection_double }
+    allow(connection_double).to receive(:get) { group_response }
+  end
+
+  describe "#find" do
+    let(:group_id) { "G_aBcD1234" }
+
+    it "calls get with the given id on the groups endpoint" do
+      expect(QualtricsAPI).to receive(:connection).with(subject)
+      expect(connection_double).to receive(:get).with("groups/#{group_id}", {})
+      subject.find(group_id)
+    end
+
+    context "when the response status is 200" do
+      before do
+        expect(group_response.status).to eq 200
+      end
+
+      it "returns the group" do
+        expect(subject.find(group_id)).to be_a QualtricsAPI::Group
+      end
+    end
+
+    context "when the response status is not 200" do
+      let(:response_status) { 404 }
+
+      it "returns nil" do
+        expect(subject.find(group_id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/group_spec.rb
+++ b/spec/lib/group_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe QualtricsAPI::Group do
+  subject { described_class.new qualtrics_response }
+  let(:qualtrics_response) { {
+    "id" => "UR_aBcD1234",
+    "type" => "invite",
+    "divisionId" => "D_abc123",
+    "name" => "Group One",
+    "autoMembership" => false,
+    "creationDate" => "2019-01-01",
+    "creatorId" => "U_abc123"
+  } }
+
+  it { is_expected.to have_attributes(
+    id: qualtrics_response["id"],
+    type: qualtrics_response["type"],
+    division_id: qualtrics_response["divisionId"],
+    name: qualtrics_response["name"],
+    auto_membership: qualtrics_response["autoMembership"],
+    creation_date: qualtrics_response["creationDate"],
+    creator_id: qualtrics_response["creatorId"])
+  }
+end

--- a/spec/lib/library_spec.rb
+++ b/spec/lib/library_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe QualtricsAPI::Library do
+  subject { described_class.new }
+  let(:collection_double) { instance_double(QualtricsAPI::LibraryMessageCollection) }
+
+  before do
+    allow(subject).to receive(:id) { "some_id" }
+    allow(QualtricsAPI::LibraryMessageCollection).to receive(:new) { collection_double }
+    allow(collection_double).to receive(:propagate_connection) { collection_double }
+  end
+
+  describe "#message_collection" do
+    it "creates a LibraryMessageCollection with the same connection" do
+      expect(QualtricsAPI::LibraryMessageCollection).to receive(:new).with(id: subject.id)
+      expect(collection_double).to receive(:propagate_connection).with(subject)
+      expect(subject.message_collection).to be collection_double
+    end
+  end
+
+  describe "#messages" do
+    it "gets all messages for the user" do
+      expect(collection_double).to receive(:all)
+      subject.messages
+    end
+  end
+end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe QualtricsAPI::User do
   subject { described_class.new qualtrics_response }
-  let(:collection_double) { instance_double(QualtricsAPI::LibraryMessageCollection) }
   let(:qualtrics_response) { {
     "id" => "UR_aBcD1234",
     "username" => "somedude",
@@ -37,11 +36,6 @@ describe QualtricsAPI::User do
     }
   } }
 
-  before do
-    allow(QualtricsAPI::LibraryMessageCollection).to receive(:new) { collection_double }
-    allow(collection_double).to receive(:propagate_connection) { collection_double }
-  end
-
   it { is_expected.to have_attributes(
     id: qualtrics_response["id"],
     division_id: qualtrics_response["divisionId"],
@@ -63,19 +57,4 @@ describe QualtricsAPI::User do
     response_counts: qualtrics_response["responseCounts"],
     permissions: qualtrics_response["permissions"].deep_transform_keys { |key| key.underscore.to_sym })
   }
-
-  describe "#message_collection" do
-    it "creates a LibraryMessageCollection with the same connection" do
-      expect(QualtricsAPI::LibraryMessageCollection).to receive(:new).with(id: subject.id)
-      expect(collection_double).to receive(:propagate_connection).with(subject)
-      expect(subject.message_collection).to be collection_double
-    end
-  end
-
-  describe "#messages" do
-    it "gets all messages for the user" do
-      expect(collection_double).to receive(:all)
-      subject.messages
-    end
-  end
 end


### PR DESCRIPTION
This PR adds Group and GroupCollection models. It also creates a new Library base class that User and Group inherit from to get library messages.