### PR TITLE
Raise FileNotReadyError when export url missing

### DIFF
--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -49,4 +49,5 @@ module QualtricsAPI
   class UnauthorizedError < StandardError; end
   class InternalServerError < StandardError; end
   class NotSupported < StandardError; end
+  class FileNotReadyError < StandardError; end
 end

--- a/lib/qualtrics_api/response_export.rb
+++ b/lib/qualtrics_api/response_export.rb
@@ -32,7 +32,9 @@ module QualtricsAPI
     end
 
     def open(&block)
-      Kernel.open(@file_url, QualtricsAPI.connection(self).headers, &block)
+      raise QualtricsAPI::FileNotReadyError, "Cannot open exported file because the file url is missing." if file_url.nil?
+
+      Kernel.open(file_url, QualtricsAPI.connection(self).headers, &block)
     end
   end
 end

--- a/spec/lib/response_export_spec.rb
+++ b/spec/lib/response_export_spec.rb
@@ -94,10 +94,43 @@ describe QualtricsAPI::ResponseExport do
         expect(subject).to eq(described_class.new(subject.attributes))
       end
     end
-  
+
     context 'when different' do
       it 'returns false' do
         expect(subject).not_to eq(described_class.new)
+      end
+    end
+  end
+
+  describe "#open" do
+    before do
+      subject.instance_variable_set(:@completed, true)
+    end
+
+    context "when file_url is present" do
+      let(:connection_double) { instance_double(Faraday::Connection) }
+      let(:connection_headers) { { test: "header" } }
+
+      before do
+        subject.instance_variable_set(:@file_url, "some_url")
+
+        allow(QualtricsAPI).to receive(:connection).with(subject) { connection_double }
+        allow(connection_double).to receive(:headers) { connection_headers }
+      end
+
+      it "opens the linked file with the file_url and qualtrics connection" do
+        expect(Kernel).to receive(:open).with("some_url", connection_headers)
+        subject.open
+      end
+    end
+
+    context "when file_url is nil" do
+      before do
+        subject.instance_variable_set(:@file_url, nil)
+      end
+
+      it "raises a FileNotReadyError" do
+        expect { subject.open }.to raise_error(QualtricsAPI::FileNotReadyError, "Cannot open exported file because the file url is missing.")
       end
     end
   end


### PR DESCRIPTION
This PR raises a new `FileNotReadyError` exception if a response export is being opened but there is no file_url present.