### PR TITLE
Raise 404 error message like other http errors

### DIFF
--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -12,7 +12,7 @@ module QualtricsAPI
     def raise_http_errors(code, body)
       case code
       when 404
-        raise NotFoundError, "Not Found"
+        raise NotFoundError, error_message(JSON.parse(body))
       when 400
         raise BadRequestError, error_message(JSON.parse(body))
       when 401


### PR DESCRIPTION
This PR updates 404 error handling to include the response error status, code, and message, just like we do with other http errors.