### PR TITLE
IE-539 Address Ruby 3 Changes to Kernel Behavior

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -22,8 +22,7 @@ jobs:
         env:
           RAILS_ENV: test
         run: |
-          gem install bundler:1.17.3
-          bundle _1.17.3_ install
+          bundle install
 
       - name: Run tests
         env:

--- a/lib/qualtrics_api/response_export.rb
+++ b/lib/qualtrics_api/response_export.rb
@@ -34,7 +34,7 @@ module QualtricsAPI
     def open(&block)
       raise QualtricsAPI::FileNotReadyError, "Cannot open exported file because the file url is missing." if file_url.nil?
 
-      Kernel.open(file_url, **QualtricsAPI.connection(self).headers, &block)
+      URI.open(file_url, **QualtricsAPI.connection(self).headers, &block)
     end
   end
 end

--- a/lib/qualtrics_api/version.rb
+++ b/lib/qualtrics_api/version.rb
@@ -1,3 +1,3 @@
 module QualtricsAPI
-  VERSION = "0.0.16".freeze
+  VERSION = "0.1.0".freeze
 end

--- a/qualtrics_api.gemspec
+++ b/qualtrics_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware", ">= 0.12.2"
   spec.add_dependency "virtus", ">= 1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.4.0"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "vcr", "~> 3.0"

--- a/qualtrics_api.gemspec
+++ b/qualtrics_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware", ">= 0.12.2"
   spec.add_dependency "virtus", ">= 1.0"
 
-  spec.add_development_dependency "bundler", "~> 2.4.0"
+  spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "vcr", "~> 3.0"

--- a/spec/lib/response_export_spec.rb
+++ b/spec/lib/response_export_spec.rb
@@ -109,7 +109,7 @@ describe QualtricsAPI::ResponseExport do
 
     it "conforms to ruby 3 keyword-argument format" do
       subject.instance_variable_set(:@file_url, "some_url")
-      expect(Kernel).to receive(:open) do |*args, **kwargs|
+      expect(URI).to receive(:open) do |*args, **kwargs|
         expect(args).to eq ["some_url"]
         expect(kwargs.class).to eq Faraday::Utils::Headers
       end
@@ -128,7 +128,7 @@ describe QualtricsAPI::ResponseExport do
       end
 
       it "opens the linked file with the file_url and qualtrics connection" do
-        expect(Kernel).to receive(:open).with("some_url", connection_headers)
+        expect(URI).to receive(:open).with("some_url", connection_headers)
         subject.open
       end
     end


### PR DESCRIPTION
In Ruby 2, Kernel.open worked for both local and remote files.
In Ruby 3, this was changed such that Kernel.open would only open local files.
URI.open became the prefered syntax for opening remote files.
https://github.com/ruby/open-uri/commit/53862fa35887a34a8060aebf2241874240c2986a

[Bug ticket](https://kantata.atlassian.net/browse/IE-539)