### PR TITLE
[IE-673] Update api errors handling

### DIFF
--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -2,6 +2,8 @@ require 'logger'
 
 module QualtricsAPI
   class RequestErrorHandler < Faraday::Response::Middleware
+    HTTP_RESPONSE_ERROR_RANGE = 400..599
+
     def on_complete(env)
       raise_http_errors(env[:status], env[:body])
       show_notices(env[:body])
@@ -14,6 +16,8 @@ module QualtricsAPI
       when 200, 202
         return
       else
+        return unless HTTP_RESPONSE_ERROR_RANGE.include?(code)
+
         raise http_error_class(code), error_message(JSON.parse(body))
       end
     end

--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -11,14 +11,30 @@ module QualtricsAPI
 
     def raise_http_errors(code, body)
       case code
-      when 404
-        raise NotFoundError, error_message(JSON.parse(body))
       when 400
         raise BadRequestError, error_message(JSON.parse(body))
       when 401
         raise UnauthorizedError, error_message(JSON.parse(body))
+      when 403
+        raise ForbiddenError, error_message(JSON.parse(body))
+      when 404
+        raise NotFoundError, error_message(JSON.parse(body))
+      when 409
+        raise ConflictError, error_message(JSON.parse(body))
+      when 413
+        raise RequestEntityTooLargeError, error_message(JSON.parse(body))
+      when 414
+        raise URITooLongError, error_message(JSON.parse(body))
+      when 415
+        raise UnsupportedMediaTypeError, error_message(JSON.parse(body))
+      when 429
+        raise TooManyRequestsError, error_message(JSON.parse(body))
       when 500
         raise InternalServerError, error_message(JSON.parse(body))
+      when 503
+        raise TemporaryInternalServerError, error_message(JSON.parse(body))
+      when 504
+        raise GatewayTimeoutError, error_message(JSON.parse(body))
       end
     end
 
@@ -43,11 +59,21 @@ module QualtricsAPI
     end
   end
 
-  class NotYetFetchedError < StandardError; end
-  class NotFoundError < StandardError; end
+  # HTTP Reponse Status Errors
   class BadRequestError < StandardError; end
   class UnauthorizedError < StandardError; end
+  class ForbiddenError < StandardError; end
+  class NotFoundError < StandardError; end
+  class ConflictError < StandardError; end
+  class RequestEntityTooLargeError < StandardError; end
+  class URITooLongError < StandardError; end
+  class UnsupportedMediaTypeError < StandardError; end
+  class TooManyRequestsError < StandardError; end
   class InternalServerError < StandardError; end
+  class TemporaryInternalServerError < StandardError; end
+  class GatewayTimeoutError < StandardError; end
+
+  # Application errors
   class NotSupported < StandardError; end
   class FileNotReadyError < StandardError; end
 end

--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -12,14 +12,9 @@ module QualtricsAPI
     private
 
     def raise_http_errors(code, body)
-      case code
-      when 200, 202
-        return
-      else
-        return unless HTTP_RESPONSE_ERROR_RANGE.include?(code)
+      return unless HTTP_RESPONSE_ERROR_RANGE.include?(code)
 
-        raise http_error_class(code), error_message(JSON.parse(body))
-      end
+      raise http_error_class(code), error_message(JSON.parse(body))
     end
 
     def http_error_class(code)

--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -11,30 +11,41 @@ module QualtricsAPI
 
     def raise_http_errors(code, body)
       case code
+      when 200, 202
+        return
+      else
+        raise http_error_class(code), error_message(JSON.parse(body))
+      end
+    end
+
+    def http_error_class(code)
+      case code
       when 400
-        raise BadRequestError, error_message(JSON.parse(body))
+        BadRequestError
       when 401
-        raise UnauthorizedError, error_message(JSON.parse(body))
+        UnauthorizedError
       when 403
-        raise ForbiddenError, error_message(JSON.parse(body))
+        ForbiddenError
       when 404
-        raise NotFoundError, error_message(JSON.parse(body))
+        NotFoundError
       when 409
-        raise ConflictError, error_message(JSON.parse(body))
+        ConflictError
       when 413
-        raise RequestEntityTooLargeError, error_message(JSON.parse(body))
+        RequestEntityTooLargeError
       when 414
-        raise URITooLongError, error_message(JSON.parse(body))
+        URITooLongError
       when 415
-        raise UnsupportedMediaTypeError, error_message(JSON.parse(body))
+        UnsupportedMediaTypeError
       when 429
-        raise TooManyRequestsError, error_message(JSON.parse(body))
+        TooManyRequestsError
       when 500
-        raise InternalServerError, error_message(JSON.parse(body))
+        InternalServerError
       when 503
-        raise TemporaryInternalServerError, error_message(JSON.parse(body))
+        TemporaryInternalServerError
       when 504
-        raise GatewayTimeoutError, error_message(JSON.parse(body))
+        GatewayTimeoutError
+      else
+        UnknownResponseError
       end
     end
 
@@ -72,6 +83,7 @@ module QualtricsAPI
   class InternalServerError < StandardError; end
   class TemporaryInternalServerError < StandardError; end
   class GatewayTimeoutError < StandardError; end
+  class UnknownResponseError < StandardError; end
 
   # Application errors
   class NotSupported < StandardError; end

--- a/lib/qualtrics_api/version.rb
+++ b/lib/qualtrics_api/version.rb
@@ -1,3 +1,3 @@
 module QualtricsAPI
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end


### PR DESCRIPTION
# Description
When one of our customers was running a scenario that relied on creating a survey some events were not being processed and were raising an `undefined method `merge' for nil:NilClass`. 

This happened because the Qualtrics API is returning something other than the successful response the library relies on, and this response code was not listed under the `RequestErrorHandler`, which should handle everything that is not a success. 

To make sure we will have all the information needed when any error messages are returned, we are adding all missing response errors to the handler.

[Qualtrics Error Responses](https://api.qualtrics.com/3ab4b937676d5-responses)
** You have to click on the third `json` tab to see an example of an error response.

<img width="1060" alt="image" src="https://github.com/mavenlink/qualtrics_api/assets/142915992/902f9bfc-c64d-4ae1-8268-d1fa2527bd7d">

# Resolves
[IE-673](https://kantata.atlassian.net/browse/IE-673)

[IE-673]: https://kantata.atlassian.net/browse/IE-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ