### PR TITLE
[IE-962] Bump dependency to allow faraday 2 releases

### DIFF
--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -5,7 +5,8 @@ require 'json'
 require 'open-uri'
 require 'virtus'
 require "faraday"
-require "faraday_middleware"
+require "faraday/follow_redirects"
+require "faraday/multipart"
 
 require "qualtrics_api/version"
 require "qualtrics_api/request_error_handler"

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -47,9 +47,10 @@ module QualtricsAPI
       Faraday.new(url: QualtricsAPI.url(data_center_id), headers: { "X-API-TOKEN" => api_token }.merge(custom_headers)) do |faraday|
         faraday.request :multipart
         faraday.request :json
-        faraday.response :json, :content_type => /\bjson$/
 
-        faraday.use FaradayMiddleware::FollowRedirects
+        faraday.response :json, :content_type => /\bjson$/
+        faraday.response :follow_redirects
+
         faraday.use QualtricsAPI::RequestErrorHandler
 
         faraday.adapter Faraday.default_adapter

--- a/lib/qualtrics_api/request_error_handler.rb
+++ b/lib/qualtrics_api/request_error_handler.rb
@@ -1,7 +1,7 @@
 require 'logger'
 
 module QualtricsAPI
-  class RequestErrorHandler < Faraday::Response::Middleware
+  class RequestErrorHandler < Faraday::Middleware
     HTTP_RESPONSE_ERROR_RANGE = 400..599
 
     def on_complete(env)

--- a/lib/qualtrics_api/version.rb
+++ b/lib/qualtrics_api/version.rb
@@ -1,3 +1,3 @@
 module QualtricsAPI
-  VERSION = "0.1.1".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/qualtrics_api.gemspec
+++ b/qualtrics_api.gemspec
@@ -20,14 +20,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.0.6'
+  spec.required_ruby_version = ">= 3.0.6"
 
-  spec.add_dependency "activesupport", "~> 6.1.7.6"
-  spec.add_dependency "faraday", ">= 0.13.1"
-  spec.add_dependency "faraday_middleware", ">= 0.12.2"
+  spec.add_dependency "activesupport", "~> 6.1"
+  spec.add_dependency "faraday", "~> 2"
+  spec.add_dependency "faraday-follow_redirects", "~> 0.3"
+  spec.add_dependency "faraday-multipart", "~> 1.1"
   spec.add_dependency "virtus", ">= 1.0"
 
-  spec.add_development_dependency "bundler", "~> 2.2.0"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "vcr", "~> 3.0"


### PR DESCRIPTION
We need to move away from Faraday 1.0 in Konekti but this gem strictly requires us to use 1.x. 

This pull request aims to bump the dependencies so we solve the Faraday problem and also 

### Notes

Some middleware needed to be changed so we followed [Awesome Faraday](https://github.com/lostisland/awesome-faraday) instructions. 